### PR TITLE
fix if/else logic in process-shell-choose

### DIFF
--- a/essh.el
+++ b/essh.el
@@ -79,9 +79,9 @@ On success, return 0.  Otherwise, go as far as possible and return -1."
 	   (setq outpr (get-process "shell"))
 	   (sleep-for 0.5)))
 (if (eq shelln 1)
-    (setq outpr (get-process (elt shelllist 0))))
-(if (> shelln 1)
-    (get-buffer-process (shell-buffer-completing-read))))
+    (setq outpr (get-process (elt shelllist 0)))
+  (if (> shelln 1)
+      (get-buffer-process (shell-buffer-completing-read)))))
 
 (defun shell-eval-line (sprocess command)
   "Evaluates a single command into the shell process."


### PR DESCRIPTION
* put (if (> shelln 1) ...) in the else clause of (if (eq shelln 1)
  ...). This seems to fix things on emacs 25. Not exactly sure when this
  broke, but in going from emacs24 to emacs25 this change seems to be
  required to make things work.